### PR TITLE
Pass a value for the new internalFormat argument for TexImage2D

### DIFF
--- a/driver/gldriver/screen.go
+++ b/driver/gldriver/screen.go
@@ -99,7 +99,7 @@ func (s *screenImpl) NewTexture(size image.Point) (screen.Texture, error) {
 	}
 
 	glctx.BindTexture(gl.TEXTURE_2D, t.id)
-	glctx.TexImage2D(gl.TEXTURE_2D, 0, size.X, size.Y, gl.RGBA, gl.UNSIGNED_BYTE, nil)
+	glctx.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, size.X, size.Y, gl.RGBA, gl.UNSIGNED_BYTE, nil)
 	glctx.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
 	glctx.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
 	glctx.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)


### PR DESCRIPTION
A new argument was added to TexImage2D which accepts an internal color format for the texture. It seems that we can just pass RGBA to this as that's what we're passing as the format anyway.

Change in `golang.org/x/mobile/gl`: https://github.com/golang/mobile/commit/0ff817254b04da935cce10d2d1270ccf047fbbd7