### PR TITLE
Call windowClosing even if nextResponder is NULL

### DIFF
--- a/driver/gldriver/cocoa.m
+++ b/driver/gldriver/cocoa.m
@@ -208,15 +208,12 @@ uint64 threadID() {
 }
 
 - (void)windowWillClose:(NSNotification *)notification {
-	// TODO: is this right? Closing a window via the top-left red button
-	// seems to return early without ever calling windowClosing.
-	if (self.window.nextResponder == NULL) {
-		return; // already called close
-	}
-
 	windowClosing((GoUintptr)self);
-	[self.window.nextResponder release];
-	self.window.nextResponder = NULL;
+
+	if (self.window.nextResponder != NULL) {
+		[self.window.nextResponder release];
+		self.window.nextResponder = NULL;
+	}
 }
 @end
 


### PR DESCRIPTION
It looks like changing this still only calls `windowClosing` once when exiting with ⌘Q, but it is now also called when using the red "close" button in the top left of the window.

This fixes oakmound/oak#78.